### PR TITLE
An issue exists on a mac if you ctrl+click on a sortable element

### DIFF
--- a/app/assets/javascripts/activeadmin-orderable.js
+++ b/app/assets/javascripts/activeadmin-orderable.js
@@ -5,6 +5,18 @@
 
   $.fn.activeAdminSortable = function() {
     this.sortable({
+      start: function(event, ui) {
+        // disable ctrl click triggering
+        var $sortable = $(this);
+        if (event.ctrlKey) {
+          // this is done to address a bug in jQuery.UI
+          // we cannot cancel an in-progress sort without exceptions
+          setTimeout(function() {
+            $sortable.sortable('cancel');
+          }, 0);
+        }
+      },
+
       update: function(event, ui) {
         var item = ui.item.find('[data-sort-url]');
         var url = item.data('sort-url');


### PR DESCRIPTION
after the contextual menu is dismissed, the element starts sorting

- cancel the sorting if it is a ctrl click
- workaround jquery-ui bug for cancelling an in-progress sort

Caveat
- there is a flash of element movement that is undesirable in order
to cancel the sort. blame jquery-ui